### PR TITLE
fix aprsc address resolve issue

### DIFF
--- a/aprsc.dockerfile
+++ b/aprsc.dockerfile
@@ -17,4 +17,7 @@ EXPOSE 14580
 EXPOSE 10155
 EXPOSE 14501
 
-CMD /opt/aprsc/sbin/aprsc -u aprsc -t /opt/aprsc -c /etc/aprsc.conf
+WORKDIR /opt/aprsc
+USER aprsc
+
+CMD /opt/aprsc/sbin/aprsc -c /opt/aprsc/etc/aprsc.conf


### PR DESCRIPTION
I fixed aprsc address resolve issue using docker described in #20. There's a problem with chroot (that's used by '-u' switch) and libc. This launching method avoid chrooting and fixes address resolve issue.