### PR TITLE
Fix missing altitude on popup

### DIFF
--- a/htdocs/public/js/trackdirect.min.js
+++ b/htdocs/public/js/trackdirect.min.js
@@ -733,7 +733,7 @@ tailDistanceUnit+
 "</span>");return distanceDiv;}
 return null;};trackdirect.models.InfoWindow.prototype._getPacketSpeedAltitudeCourseDiv=function(){if(Math.round(this._marker.packet.speed)!=0||Math.round(this._marker.packet.course)!=0||Math.round(this._marker.packet.altitude)!=0){var speedDiv=$(document.createElement("div"));speedDiv.css("clear","both");speedDiv.css("font-weight","bold");if(this._marker.packet.speed!==null){if(this._defaultMap.state.useImperialUnit){speedDiv.append(Math.round(trackdirect.services.imperialConverter.convertKilometerToMile(this._marker.packet.speed))+" mph ");}else{speedDiv.append(Math.round(this._marker.packet.speed)+" km/h ");}}
 if(this._marker.packet.course!==null){speedDiv.append(Math.round(this._marker.packet.course)+"&deg; ");}
-if(this._marker.packet.course!==null){if(this._defaultMap.state.useImperialUnit){speedDiv.append(" alt "+
+if(this._marker.packet.altitude!==null){if(this._defaultMap.state.useImperialUnit){speedDiv.append(" alt "+
 Math.round(trackdirect.services.imperialConverter.convertMeterToFeet(this._marker.packet.altitude))+
 " ft ");}else{speedDiv.append(" alt "+Math.round(this._marker.packet.altitude)+" m ");}}
 return speedDiv;}

--- a/jslib/src/trackdirect/models/InfoWindow.js
+++ b/jslib/src/trackdirect/models/InfoWindow.js
@@ -819,7 +819,7 @@ trackdirect.models.InfoWindow.prototype._getPacketSpeedAltitudeCourseDiv =
         speedDiv.append(Math.round(this._marker.packet.course) + "&deg; ");
       }
 
-      if (this._marker.packet.course !== null) {
+      if (this._marker.packet.altitude !== null) {
         if (this._defaultMap.state.useImperialUnit) {
           speedDiv.append(
             " alt " +


### PR DESCRIPTION
Altitude label is missing on the station dialog popup.  It is sometimes present in the packet data even on stations that are not moving. Looks like this was just a type on the javascript.