### PR TITLE
Add missing code backtick in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cd trackdirect
 Before installing all python requirements it is likly that you need to upgrade pyOpenSSL.
 ```
 sudo python -m easy_install --upgrade pyOpenSSL
-``
+```
 
 Install needed python libs
 ```


### PR DESCRIPTION
This was causing the code blocks and explanatory text to be the reverse of what was intended.