### PR TITLE
remove ws server url and external port

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cd trackdirect
 Before installing all python requirements it is likly that you need to upgrade pyOpenSSL.
 ```
 sudo python -m easy_install --upgrade pyOpenSSL
-``
+```
 
 Install needed python libs
 ```

--- a/server/bin/wsserver.py
+++ b/server/bin/wsserver.py
@@ -27,9 +27,7 @@ def master(options, trackDirectLogger):
     trackDirectLogger.warning("Starting master with PID " + str(workerPid) + " (on CPU id(s): " + ','.join(map(str, p.cpu_affinity())) + ")")
 
     try:
-        factory = WebSocketServerFactory(
-            "ws://" + config.websocketHostname + ":" + str(config.websocketPort),
-            externalPort = config.websocketExternalPort)
+        factory = WebSocketServerFactory()
         factory.protocol = trackdirect.TrackDirectWebsocketServer
 
         resource = WebSocketResource(factory)


### PR DESCRIPTION
for docker usage behind a web router/load balancer (like Traefik) it is very very difficult to find out the correct settings for the url which must be used for the ws server. It is way easier to leave this fields empty in the constructor.