### PR TITLE
Add maidenhead gridsquare to station overview

### DIFF
--- a/htdocs/public/views/overview.php
+++ b/htdocs/public/views/overview.php
@@ -228,6 +228,11 @@
                         <?php echo round($station->latestConfirmedLatitude, 5); ?>, <?php echo round($station->latestConfirmedLongitude, 5); ?>
                     </div>
                 </div>
+                <div>
+                    <div class="overview-content-summary-hr-indent">Gridsquare:</div>
+                    <div id="overview-content-latest-gridsquare" class="overview-content-summary-cell-position" title="Maidenhead gridsquare (calculated from position)">
+                    </div>
+                </div>
 
                 <div>
                     <div class="overview-content-summary-hr-indent">Receive Time:</div>
@@ -534,6 +539,8 @@
             if ($('#latest-timestamp-age').length && $('#latest-timestamp-age').html().trim() != '' && !isNaN($('#latest-timestamp-age').html().trim())) {
                 $('#latest-timestamp-age').html(moment(new Date(1000 * $('#latest-timestamp-age').html())).locale('en').fromNow());
             }
+
+            $('#overview-content-latest-gridsquare').html(trackdirect.models.Map.prototype._getMaidenheadLocatorFromGpsDecimal(<?php echo $station->latestConfirmedLatitude ?>, <?php echo $station->latestConfirmedLongitude ?>));
 
             if (window.trackdirect) {
                 <?php if ($station->latestConfirmedLatitude != null && $station->latestConfirmedLongitude != null) : ?>


### PR DESCRIPTION
Would be useful to have the maidenhead gridsquare on the station overview as well. Example:

![image](https://github.com/qvarforth/trackdirect/assets/7112907/4c181d76-d9e3-4a73-9088-41bff563283f)
