### PR TITLE
Github Actions Docker images auto build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,75 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build-db:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file trackdirect-db.dockerfile --tag ghcr.io/mrtalon63/trackdirect-db:latest
+    - name: Create image with Action ID
+      run: docker tag ghcr.io/mrtalon63/trackdirect-db:latest ghcr.io/mrtalon63/trackdirect-db:${{ github.RUN_ID }}
+    - name: Push both images to ghcr.io
+      run: docker push ghcr.io/mrtalon63/trackdirect-db:latest && ghcr.io/mrtalon63/trackdirect-db:${{ github.RUN_ID }}
+
+  build-apache:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file trackdirect-apache.dockerfile --tag ghcr.io/mrtalon63/trackdirect-apache:latest
+    - name: Create image with Action ID
+      run: docker tag ghcr.io/mrtalon63/trackdirect-apache:latest ghcr.io/mrtalon63/trackdirect-apache:${{ github.RUN_ID }}
+    - name: Push both images to ghcr.io
+      run: docker push ghcr.io/mrtalon63/trackdirect-apache:latest && ghcr.io/mrtalon63/trackdirect-apache:${{ github.RUN_ID }}
+
+  build-python:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file trackdirect-python.dockerfile --tag ghcr.io/mrtalon63/trackdirect-python:latest
+    - name: Create image with Action ID
+      run: docker tag ghcr.io/mrtalon63/trackdirect-python:latest ghcr.io/mrtalon63/trackdirect-python:${{ github.RUN_ID }}
+    - name: Push both images to ghcr.io
+      run: docker push ghcr.io/mrtalon63/trackdirect-python:latest && ghcr.io/mrtalon63/trackdirect-python:${{ github.RUN_ID }}
+
+  build-aprsc:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file trackdirect-aprsc.dockerfile --tag ghcr.io/mrtalon63/trackdirect-aprsc:latest
+    - name: Create image with Action ID
+      run: docker tag ghcr.io/mrtalon63/trackdirect-aprsc:latest ghcr.io/mrtalon63/trackdirect-aprsc:${{ github.RUN_ID }}
+    - name: Push both images to ghcr.io
+      run: docker push ghcr.io/mrtalon63/trackdirect-aprsc:latest && ghcr.io/mrtalon63/trackdirect-aprsc:${{ github.RUN_ID }}
+
+  
+  build-cron:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file trackdirect-cron.dockerfile --tag ghcr.io/mrtalon63/trackdirect-cron:latest
+    - name: Create image with Action ID
+      run: docker tag ghcr.io/mrtalon63/trackdirect-cron:latest ghcr.io/mrtalon63/trackdirect-cron:${{ github.RUN_ID }}
+    - name: Push both images to ghcr.io
+      run: docker push ghcr.io/mrtalon63/trackdirect-cron:latest && ghcr.io/mrtalon63/trackdirect-cron:${{ github.RUN_ID }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,6 +8,12 @@ on:
 
 jobs:
 
+  repo-name:
+    runs-on: ubuntu-latest
+    steps:
+     - name: lowercase github.repository
+       run: echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> ${GITHUB_ENV}
+
   docker-build-db:
     runs-on: ubuntu-latest
     steps:
@@ -27,8 +33,8 @@ jobs:
           file: trackdirect-db.dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}-db:latest
-            ghcr.io/${{ github.repository }}-db:${{ github.RUN_ID }}
+            ghcr.io/${{ env.IMAGE_NAME }}-db:latest
+            ghcr.io/${{ env.IMAGE_NAME }}-db:${{ github.RUN_ID }}
 
   docker-build-apache:
     runs-on: ubuntu-latest
@@ -49,8 +55,8 @@ jobs:
           file: trackdirect-apache.dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}-apache:latest
-            ghcr.io/${{ github.repository }}-apache:${{ github.RUN_ID }}
+            ghcr.io/${{ env.IMAGE_NAME }}-apache:latest
+            ghcr.io/${{ env.IMAGE_NAME }}-apache:${{ github.RUN_ID }}
 
   docker-build-python:
     runs-on: ubuntu-latest
@@ -71,8 +77,8 @@ jobs:
           file: trackdirect-python.dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}-python:latest
-            ghcr.io/${{ github.repository }}-python:${{ github.RUN_ID }}
+            ghcr.io/${{ env.IMAGE_NAME }}-python:latest
+            ghcr.io/${{ env.IMAGE_NAME }}-python:${{ github.RUN_ID }}
 
   docker-build-aprsc:
     runs-on: ubuntu-latest
@@ -93,8 +99,8 @@ jobs:
           file: trackdirect-aprsc.dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}-aprsc:latest
-            ghcr.io/${{ github.repository }}-aprsc:${{ github.RUN_ID }}
+            ghcr.io/${{ env.IMAGE_NAME }}-aprsc:latest
+            ghcr.io/${{ env.IMAGE_NAME }}-aprsc:${{ github.RUN_ID }}
 
   docker-build-cron:
     runs-on: ubuntu-latest
@@ -115,5 +121,5 @@ jobs:
           file: trackdirect-cron.dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}-cron:latest
-            ghcr.io/${{ github.repository }}-cron:${{ github.RUN_ID }}
+            ghcr.io/${{ env.IMAGE_NAME }}-cron:latest
+            ghcr.io/${{ env.IMAGE_NAME }}-cron:${{ github.RUN_ID }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,12 +8,6 @@ on:
 
 jobs:
 
-  repo-name:
-    runs-on: ubuntu-latest
-    steps:
-     - name: lowercase github.repository
-       run: echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> ${GITHUB_ENV}
-
   docker-build-db:
     runs-on: ubuntu-latest
     steps:
@@ -27,6 +21,8 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: lowercase github.repository
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> ${GITHUB_ENV}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -49,6 +45,8 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: lowercase github.repository
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> ${GITHUB_ENV}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -71,6 +69,8 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: lowercase github.repository
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> ${GITHUB_ENV}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -93,6 +93,8 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: lowercase github.repository
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> ${GITHUB_ENV}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -115,6 +117,8 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: lowercase github.repository
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> ${GITHUB_ENV}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,20 +8,28 @@ on:
 
 jobs:
 
-  build-db:
-
+  docker-build-db:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Login to Docker
-      run: docker login ghcr.io
-    - name: Build the Docker image
-      run: docker build . --file trackdirect-db.dockerfile --tag ghcr.io/mrtalon63/trackdirect-db:latest
-    - name: Create image with Action ID
-      run: docker tag ghcr.io/mrtalon63/trackdirect-db:latest ghcr.io/mrtalon63/trackdirect-db:${{ github.RUN_ID }}
-    - name: Push both images to ghcr.io
-      run: docker push ghcr.io/mrtalon63/trackdirect-db:latest && ghcr.io/mrtalon63/trackdirect-db:${{ github.RUN_ID }}
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: mrtalon63
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: trackdirect-db.dockerfile
+          push: true
+          tags: |
+            ghcr.io/mrtalon63/trackdirect-db:latest
+            ghcr.io/mrtalon63/trackdirect-db:${{ github.RUN_ID }}
 
   build-apache:
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: mrtalon63
+          username: ${{ github.repository_owner}}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -27,8 +27,8 @@ jobs:
           file: trackdirect-db.dockerfile
           push: true
           tags: |
-            ghcr.io/mrtalon63/trackdirect-db:latest
-            ghcr.io/mrtalon63/trackdirect-db:${{ github.RUN_ID }}
+            ghcr.io/${{ github.repository }}-db:latest
+            ghcr.io/${{ github.repository }}-db:${{ github.RUN_ID }}
 
   docker-build-apache:
     runs-on: ubuntu-latest
@@ -37,7 +37,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: mrtalon63
+          username: ${{ github.repository_owner}}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -49,8 +49,8 @@ jobs:
           file: trackdirect-apache.dockerfile
           push: true
           tags: |
-            ghcr.io/mrtalon63/trackdirect-apache:latest
-            ghcr.io/mrtalon63/trackdirect-apache:${{ github.RUN_ID }}
+            ghcr.io/${{ github.repository }}-apache:latest
+            ghcr.io/${{ github.repository }}-apache:${{ github.RUN_ID }}
 
   docker-build-python:
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: mrtalon63
+          username: ${{ github.repository_owner}}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -71,8 +71,8 @@ jobs:
           file: trackdirect-python.dockerfile
           push: true
           tags: |
-            ghcr.io/mrtalon63/trackdirect-python:latest
-            ghcr.io/mrtalon63/trackdirect-python:${{ github.RUN_ID }}
+            ghcr.io/${{ github.repository }}-python:latest
+            ghcr.io/${{ github.repository }}-python:${{ github.RUN_ID }}
 
   docker-build-aprsc:
     runs-on: ubuntu-latest
@@ -81,7 +81,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: mrtalon63
+          username: ${{ github.repository_owner}}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -93,8 +93,8 @@ jobs:
           file: trackdirect-aprsc.dockerfile
           push: true
           tags: |
-            ghcr.io/mrtalon63/trackdirect-aprsc:latest
-            ghcr.io/mrtalon63/trackdirect-aprsc:${{ github.RUN_ID }}
+            ghcr.io/${{ github.repository }}-aprsc:latest
+            ghcr.io/${{ github.repository }}-aprsc:${{ github.RUN_ID }}
 
   docker-build-cron:
     runs-on: ubuntu-latest
@@ -103,7 +103,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: mrtalon63
+          username: ${{ github.repository_owner}}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -115,5 +115,5 @@ jobs:
           file: trackdirect-cron.dockerfile
           push: true
           tags: |
-            ghcr.io/mrtalon63/trackdirect-cron:latest
-            ghcr.io/mrtalon63/trackdirect-cron:${{ github.RUN_ID }}
+            ghcr.io/${{ github.repository }}-cron:latest
+            ghcr.io/${{ github.repository }}-cron:${{ github.RUN_ID }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Login to Docker
+      run: docker login ghcr.io
     - name: Build the Docker image
       run: docker build . --file trackdirect-db.dockerfile --tag ghcr.io/mrtalon63/trackdirect-db:latest
     - name: Create image with Action ID
@@ -27,6 +29,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Login to Docker
+      run: docker login ghcr.io
     - name: Build the Docker image
       run: docker build . --file trackdirect-apache.dockerfile --tag ghcr.io/mrtalon63/trackdirect-apache:latest
     - name: Create image with Action ID
@@ -40,6 +44,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Login to Docker
+      run: docker login ghcr.io
     - name: Build the Docker image
       run: docker build . --file trackdirect-python.dockerfile --tag ghcr.io/mrtalon63/trackdirect-python:latest
     - name: Create image with Action ID
@@ -53,6 +59,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Login to Docker
+      run: docker login ghcr.io
     - name: Build the Docker image
       run: docker build . --file trackdirect-aprsc.dockerfile --tag ghcr.io/mrtalon63/trackdirect-aprsc:latest
     - name: Create image with Action ID
@@ -67,6 +75,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Login to Docker
+      run: docker login ghcr.io
     - name: Build the Docker image
       run: docker build . --file trackdirect-cron.dockerfile --tag ghcr.io/mrtalon63/trackdirect-cron:latest
     - name: Create image with Action ID

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
           file: trackdirect-db.dockerfile
           push: true
           tags: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,63 +30,90 @@ jobs:
             ghcr.io/mrtalon63/trackdirect-db:latest
             ghcr.io/mrtalon63/trackdirect-db:${{ github.RUN_ID }}
 
-  build-apache:
-
+  docker-build-apache:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Login to Docker
-      run: docker login ghcr.io
-    - name: Build the Docker image
-      run: docker build . --file trackdirect-apache.dockerfile --tag ghcr.io/mrtalon63/trackdirect-apache:latest
-    - name: Create image with Action ID
-      run: docker tag ghcr.io/mrtalon63/trackdirect-apache:latest ghcr.io/mrtalon63/trackdirect-apache:${{ github.RUN_ID }}
-    - name: Push both images to ghcr.io
-      run: docker push ghcr.io/mrtalon63/trackdirect-apache:latest && ghcr.io/mrtalon63/trackdirect-apache:${{ github.RUN_ID }}
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: mrtalon63
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          file: trackdirect-apache.dockerfile
+          push: true
+          tags: |
+            ghcr.io/mrtalon63/trackdirect-apache:latest
+            ghcr.io/mrtalon63/trackdirect-apache:${{ github.RUN_ID }}
 
-  build-python:
-
+  docker-build-python:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Login to Docker
-      run: docker login ghcr.io
-    - name: Build the Docker image
-      run: docker build . --file trackdirect-python.dockerfile --tag ghcr.io/mrtalon63/trackdirect-python:latest
-    - name: Create image with Action ID
-      run: docker tag ghcr.io/mrtalon63/trackdirect-python:latest ghcr.io/mrtalon63/trackdirect-python:${{ github.RUN_ID }}
-    - name: Push both images to ghcr.io
-      run: docker push ghcr.io/mrtalon63/trackdirect-python:latest && ghcr.io/mrtalon63/trackdirect-python:${{ github.RUN_ID }}
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: mrtalon63
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          file: trackdirect-python.dockerfile
+          push: true
+          tags: |
+            ghcr.io/mrtalon63/trackdirect-python:latest
+            ghcr.io/mrtalon63/trackdirect-python:${{ github.RUN_ID }}
 
-  build-aprsc:
-
+  docker-build-aprsc:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Login to Docker
-      run: docker login ghcr.io
-    - name: Build the Docker image
-      run: docker build . --file trackdirect-aprsc.dockerfile --tag ghcr.io/mrtalon63/trackdirect-aprsc:latest
-    - name: Create image with Action ID
-      run: docker tag ghcr.io/mrtalon63/trackdirect-aprsc:latest ghcr.io/mrtalon63/trackdirect-aprsc:${{ github.RUN_ID }}
-    - name: Push both images to ghcr.io
-      run: docker push ghcr.io/mrtalon63/trackdirect-aprsc:latest && ghcr.io/mrtalon63/trackdirect-aprsc:${{ github.RUN_ID }}
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: mrtalon63
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          file: trackdirect-aprsc.dockerfile
+          push: true
+          tags: |
+            ghcr.io/mrtalon63/trackdirect-aprsc:latest
+            ghcr.io/mrtalon63/trackdirect-aprsc:${{ github.RUN_ID }}
 
-  
-  build-cron:
-
+  docker-build-cron:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Login to Docker
-      run: docker login ghcr.io
-    - name: Build the Docker image
-      run: docker build . --file trackdirect-cron.dockerfile --tag ghcr.io/mrtalon63/trackdirect-cron:latest
-    - name: Create image with Action ID
-      run: docker tag ghcr.io/mrtalon63/trackdirect-cron:latest ghcr.io/mrtalon63/trackdirect-cron:${{ github.RUN_ID }}
-    - name: Push both images to ghcr.io
-      run: docker push ghcr.io/mrtalon63/trackdirect-cron:latest && ghcr.io/mrtalon63/trackdirect-cron:${{ github.RUN_ID }}
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: mrtalon63
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          file: trackdirect-cron.dockerfile
+          push: true
+          tags: |
+            ghcr.io/mrtalon63/trackdirect-cron:latest
+            ghcr.io/mrtalon63/trackdirect-cron:${{ github.RUN_ID }}

--- a/trackdirect-db.dockerfile
+++ b/trackdirect-db.dockerfile
@@ -1,4 +1,4 @@
-FROM postgres
+FROM postgres:16
 COPY misc/database/tables/* /docker-entrypoint-initdb.d/
 COPY config/postgresql.conf /etc/postgresql.conf
 RUN chown :999 /etc/postgresql.conf

--- a/trackdirect-db.dockerfile
+++ b/trackdirect-db.dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16
+FROM postgres:17
 COPY misc/database/tables/* /docker-entrypoint-initdb.d/
 COPY config/postgresql.conf /etc/postgresql.conf
 RUN chown :999 /etc/postgresql.conf


### PR DESCRIPTION
Hi,
I've been hosting my own trackdirect instance for some time now, and I have bricked together an GH Actions config to build it after pushing to main or creating a PR. It should be good to go without any modifications as it uses ENVs available in the actions' runner.

It's my first pull request to an OSS outside my own projects, so if there's any issue please inform me, and I'll try to solve them respectively.