### PR TITLE
fix aprsz fails to install because of deprecated apt-key

### DIFF
--- a/trackdirect-aprsc.dockerfile
+++ b/trackdirect-aprsc.dockerfile
@@ -4,13 +4,15 @@ RUN apt-get update && apt-get install -y \
   gnupg \
   && rm -rf /var/lib/apt/lists/*
 
-RUN printf "deb http://aprsc-dist.he.fi/aprsc/apt noble main" >> /etc/apt/sources.list
 RUN gpg --keyserver keyserver.ubuntu.com --recv C51AA22389B5B74C3896EF3CA72A581E657A2B8D
-RUN gpg --export C51AA22389B5B74C3896EF3CA72A581E657A2B8D | apt-key add -
+RUN gpg --export C51AA22389B5B74C3896EF3CA72A581E657A2B8D > /usr/share/keyrings/aprsc-archive-keyring.gpg
+RUN printf "deb [arch=amd64 signed-by=/usr/share/keyrings/aprsc-archive-keyring.gpg] http://aprsc-dist.he.fi/aprsc/apt noble main" >> /etc/apt/sources.list
+RUN echo "APT::Key::Assert-Pubkey-Algo \">=rsa3072,>=dsa1024\";" >> /etc/apt/apt.conf.d/99weakkey-warning
 
 RUN apt-get update && apt-get install -y \
   aprsc \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /etc/apt/apt.conf.d/99weakkey-warning
 
 EXPOSE 10152
 EXPOSE 14580


### PR DESCRIPTION
apt-key is being deprecated and aprsc fails to install. This fixes this issue:
See: https://groups.google.com/g/aprsc/c/zX4OX7PRjmM/m/L3WEKF81AwAJ

Also the key for the repo signing has to weak encryption algorithm for ubuntu noble to be happy, this also add  some workaround for this.
@hessu this might be an issue for future Linux distros in the future, mayber upgrading the key should be considered ?